### PR TITLE
Fix typo in install-success notice

### DIFF
--- a/sources/amper-wrapper/resources/wrappers/installer.template.ps1
+++ b/sources/amper-wrapper/resources/wrappers/installer.template.ps1
@@ -196,7 +196,7 @@ function Main {
 
     Add-ToUserPath $installDir
     Write-Host "Installed Kotlin CLI to $targetPath"
-    Write-Host 'To get started you can run: kotlin --help (you may need to restart you shell first)'
+    Write-Host 'To get started you can run: kotlin --help (you may need to restart your shell first)'
 }
 
 Main


### PR DESCRIPTION
Changes "... restart _you_ shell ..." to "... restart _your_ shell ..."