### PR TITLE
Fix dependency resolution for Android native targets.

### DIFF
--- a/sources/dependency-resolution/src/org/jetbrains/amper/dependency/resolution/platform.kt
+++ b/sources/dependency-resolution/src/org/jetbrains/amper/dependency/resolution/platform.kt
@@ -63,7 +63,10 @@ enum class ResolutionPlatform(
     ANDROID_NATIVE_X64(PlatformType.NATIVE),
     ANDROID_NATIVE_X86(PlatformType.NATIVE);
 
-    val nativeTarget: String? = if (type == PlatformType.NATIVE) name.lowercase() else null
+    val nativeTarget: String? = if (type == PlatformType.NATIVE) when (this) {
+        ANDROID_NATIVE_ARM32, ANDROID_NATIVE_ARM64, ANDROID_NATIVE_X64, ANDROID_NATIVE_X86 -> name.replace("_NATIVE", "")
+        else -> name
+    }.lowercase() else null
     val wasmTarget: String? = if (type == PlatformType.WASM) name.lowercase().substringAfter("_") else null
 
     // TODO Copy pasted from Platform


### PR DESCRIPTION
The definition of `nativeTarget` was incorrect for Android native targets, which needed special treatment.
Without this fix, when supporting Android native targets, dependency resolution fails even for libraries that do support Android native.

For example, depending on kotlinx-io fails with:
```
Platform androidNativeArm64 is not supported by the library org.jetbrains.kotlinx:kotlinx-io-core:0.9.0
Supported platforms: [android, iosArm64, iosSimulatorArm64, iosX64, js, jvm, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
```
even although it does actually support android native.

Related: #1