### PR TITLE
Bumped built-in dataframe version to 1.0.0-rc01

### DIFF
--- a/build-sources/project-commands/module.yaml
+++ b/build-sources/project-commands/module.yaml
@@ -36,7 +36,7 @@ plugins:
         # https://github.com/JetBrains/compose-hot-reload/releases
         composeHotReload: 1.2.0-rc01
         # https://github.com/Kotlin/dataframe/releases
-        dataframe: 1.0.0-Beta5
+        dataframe: 1.0.0-rc01
         # https://www.oracle.com/nl/java/technologies/downloads/
         jdk: 21
         # https://github.com/junit-team/junit-framework/releases

--- a/sources/frontend-api/src/org/jetbrains/amper/frontend/schema/DefaultVersions.kt
+++ b/sources/frontend-api/src/org/jetbrains/amper/frontend/schema/DefaultVersions.kt
@@ -24,7 +24,7 @@ object DefaultVersions {
 
     /*managed_default*/ val compose = "1.10.3"
     /*managed_default*/ val composeHotReload = "1.2.0-rc01"
-    /*managed_default*/ val dataframe = "1.0.0-Beta5"
+    /*managed_default*/ val dataframe = "1.0.0-rc01"
     /*managed_default*/ val jdk = 21
     /*managed_default*/ val junitPlatform = "6.0.3"
     /*managed_default*/ val kotlin = "2.3.21"


### PR DESCRIPTION
Bumped built-in dataframe version to 1.0.0-rc01 since we had a new release: https://github.com/Kotlin/dataframe/discussions/1944

I ran `syncVersions`, `build`, and `tests`. Is this all that's needed?