### PR TITLE
feat(cli): support environment files

### DIFF
--- a/docs/src/cli/provisioning.md
+++ b/docs/src/cli/provisioning.md
@@ -28,6 +28,27 @@ immediately delegate to it.
 The provisioning mechanism and all relevant behaviors in the Kotlin Toolchain are designed to be safe to use concurrently.
 This means you can run as many Kotlin CLI commands as you want in parallel, and they won't disturb each other.
 
+## Loading environment files
+
+Use the `--env-file` root option to load environment variables before the Kotlin CLI initializes the project or executes
+build tasks. The path is relative to the current working directory and can use any name, such as `.env.dev` or `.env.prod`:
+
+```shell
+./kotlin --env-file .env.dev run -m server
+./kotlin --env-file .env.prod package -m server
+```
+
+The option can be repeated to layer environment-specific values over shared defaults:
+
+```shell
+./kotlin --env-file .env --env-file .env.dev run -m server
+```
+
+Variables already present in the process environment take precedence over files. When multiple files are supplied, an
+environment file supplied later takes precedence over earlier files. Environment files support blank lines, whole-line comments, and
+`NAME=value` entries with optional single or double quotes around values. They are parsed as data: shell commands and
+variable interpolation are not evaluated.
+
 ## Bootstrap cache location
 
 By default, when downloading the Kotlin Toolchain distribution, the wrapper script places it in a cache directory that is suitable

--- a/sources/amper-cli/src/org/jetbrains/amper/cli/EnvironmentFile.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/cli/EnvironmentFile.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.amper.cli
+
+import org.jetbrains.amper.intellij.CommandLineUtils
+import org.jetbrains.amper.processes.output.ProcessOutputMode
+import org.jetbrains.amper.processes.runProcess
+import java.nio.file.Path
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readLines
+
+private const val environmentFileOption = "--env-file"
+private const val wrapperPathEnvironmentVariable = "KOTLIN_CLI_WRAPPER_PATH"
+private val environmentVariableName = Regex("[A-Za-z_][A-Za-z0-9_]*")
+
+internal data class EnvironmentFileArguments(
+    val files: List<Path>,
+    val forwardedArguments: List<String>,
+)
+
+internal suspend fun restartWithEnvironmentFilesIfRequested(args: Array<String>): Int? {
+    val parsedArguments = parseEnvironmentFileArguments(args)
+    if (parsedArguments.files.isEmpty()) {
+        return null
+    }
+
+    val wrapperPath = System.getenv(wrapperPathEnvironmentVariable)
+        ?.takeIf(String::isNotBlank)
+        ?: userReadableError("Missing $wrapperPathEnvironmentVariable. Is your Kotlin Toolchain distribution intact?")
+    val environment = loadEnvironmentFiles(parsedArguments.files)
+    val command = CommandLineUtils.quoteCommandLineForCurrentPlatform(
+        listOf(wrapperPath) + parsedArguments.forwardedArguments
+    )
+    val result = runProcess(
+        command = command,
+        environment = environment,
+        outputMode = ProcessOutputMode.Inherit,
+    )
+    return result.exitCode
+}
+
+internal fun parseEnvironmentFileArguments(args: Array<String>): EnvironmentFileArguments {
+    val files = mutableListOf<Path>()
+    val forwardedArguments = mutableListOf<String>()
+    var index = 0
+    var optionsEnded = false
+
+    while (index < args.size) {
+        val argument = args[index]
+        if (optionsEnded) {
+            forwardedArguments += argument
+            index++
+            continue
+        }
+
+        when {
+            argument == "--" -> {
+                optionsEnded = true
+                forwardedArguments += argument
+            }
+            argument == environmentFileOption -> {
+                val file = args.getOrNull(index + 1)
+                    ?: userReadableError("Missing path after $environmentFileOption")
+                files.add(environmentFilePath(file))
+                index++
+            }
+            argument.startsWith("$environmentFileOption=") -> {
+                files.add(environmentFilePath(argument.substringAfter('=')))
+            }
+            else -> forwardedArguments += argument
+        }
+        index++
+    }
+    return EnvironmentFileArguments(files, forwardedArguments)
+}
+
+internal fun loadEnvironmentFiles(
+    files: List<Path>,
+    inheritedEnvironment: Map<String, String> = System.getenv(),
+): Map<String, String> {
+    return buildMap {
+        files.forEach { file ->
+            val normalizedFile = file.toAbsolutePath().normalize()
+            if (!normalizedFile.isRegularFile()) {
+                userReadableError("Environment file does not exist or is not a regular file: $normalizedFile")
+            }
+            normalizedFile.readLines().forEachIndexed { index, line ->
+                val entry = parseEnvironmentFileLine(line, normalizedFile, index + 1) ?: return@forEachIndexed
+                if (entry.first !in inheritedEnvironment) {
+                    put(entry.first, entry.second)
+                }
+            }
+        }
+    }
+}
+
+private fun environmentFilePath(value: String): Path {
+    if (value.isBlank()) {
+        userReadableError("Environment file path cannot be empty")
+    }
+    return try {
+        Path.of(value)
+    } catch (e: RuntimeException) {
+        userReadableError("Invalid environment file path: $value", cause = e)
+    }
+}
+
+private fun parseEnvironmentFileLine(line: String, file: Path, lineNumber: Int): Pair<String, String>? {
+    val declaration = line.removePrefix("\uFEFF").trim()
+    if (declaration.isEmpty() || declaration.startsWith('#')) {
+        return null
+    }
+
+    val separatorIndex = declaration.indexOf('=')
+    if (separatorIndex <= 0) {
+        invalidEnvironmentFileLine(file, lineNumber)
+    }
+    val name = declaration.substring(0, separatorIndex).trim()
+    if (!environmentVariableName.matches(name)) {
+        invalidEnvironmentFileLine(file, lineNumber)
+    }
+    val rawValue = declaration.substring(separatorIndex + 1).trim()
+    val value = unquoteEnvironmentValue(rawValue, file, lineNumber)
+    return name to value
+}
+
+private fun unquoteEnvironmentValue(value: String, file: Path, lineNumber: Int): String {
+    val quote = value.firstOrNull()?.takeIf { it == '\'' || it == '"' } ?: return value
+    if (value.length < 2 || value.last() != quote) {
+        userReadableError("Unclosed quoted value in environment file $file at line $lineNumber")
+    }
+    return value.substring(1, value.lastIndex)
+}
+
+private fun invalidEnvironmentFileLine(file: Path, lineNumber: Int): Nothing =
+    userReadableError("Invalid environment variable declaration in $file at line $lineNumber")

--- a/sources/amper-cli/src/org/jetbrains/amper/cli/commands/RootCommand.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/cli/commands/RootCommand.kt
@@ -17,6 +17,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.eagerOption
 import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.path
@@ -114,9 +115,19 @@ internal class RootCommand : SuspendingCliktCommand(name = "kotlin") {
         // Detecting this path eagerly allows showing the default value in the help.
         .default(AmperUserCacheRoot.fromCurrentUserResult().unwrap())
 
+    private val environmentFiles by option(
+        "--env-file",
+        help = "Load environment variables from a file. May be repeated; existing variables and later files win.",
+    ).path(
+        mustExist = true,
+        canBeFile = true,
+        canBeDir = false,
+    ).multiple()
+
     private val debuggingOptions by DebuggingOptions()
 
     override suspend fun run() {
+        check(environmentFiles.isEmpty()) { "Environment file arguments must be handled before CLI parsing" }
 
         // Ensure we're writing traces to the configured user cache (we start with the default in early telemetry).
         // For commands that have a project context, the traces will eventually be moved to the project build logs dir.

--- a/sources/amper-cli/src/org/jetbrains/amper/cli/main.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/cli/main.kt
@@ -25,6 +25,11 @@ private val logger = LoggerFactory.getLogger("main")
 
 suspend fun main(args: Array<String>) {
     try {
+        val restartExitCode = restartWithEnvironmentFilesIfRequested(args)
+        if (restartExitCode != null) {
+            exitProcess(restartExitCode)
+        }
+
         // We don't use RuntimeMXBean.startTime because it might give incorrect results if the system time changes.
         // The uptime value used to have a bug because of this, but now uses a more precise OS-provided value.
         // See https://bugs.openjdk.org/browse/JDK-6523160

--- a/sources/amper-cli/test/org/jetbrains/amper/cli/EnvironmentFileTest.kt
+++ b/sources/amper-cli/test/org/jetbrains/amper/cli/EnvironmentFileTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.amper.cli
+
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EnvironmentFileTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun parsesRepeatedEnvironmentFileArguments() {
+        val result = parseEnvironmentFileArguments(
+            arrayOf("--env-file", ".env", "--env-file=.env.dev", "run", "--", "--env-file", "app.env")
+        )
+
+        assertEquals(listOf(Path.of(".env"), Path.of(".env.dev")), result.files)
+        assertEquals(listOf("run", "--", "--env-file", "app.env"), result.forwardedArguments)
+    }
+
+    @Test
+    fun laterFilesOverrideEarlierFilesButNotInheritedEnvironment() {
+        val sharedFile = tempDir.resolve(".env").also { file ->
+            file.writeText(
+                """
+                SHARED=shared
+                LAYER=shared
+                INHERITED=shared
+                """.trimIndent()
+            )
+        }
+        val developmentFile = tempDir.resolve(".env.dev").also { file ->
+            file.writeText(
+                """
+                DEVELOPMENT=development
+                LAYER=development
+                INHERITED=development
+                """.trimIndent()
+            )
+        }
+
+        val result = loadEnvironmentFiles(
+            files = listOf(sharedFile, developmentFile),
+            inheritedEnvironment = mapOf("INHERITED" to "process"),
+        )
+
+        assertEquals(
+            mapOf(
+                "SHARED" to "shared",
+                "LAYER" to "development",
+                "DEVELOPMENT" to "development",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun parsesCommentsBlankLinesAndQuotedValues() {
+        val file = tempDir.resolve(".env.prod").also { path ->
+            path.writeText(
+                """
+                # Production settings
+
+                PLAIN=value
+                SINGLE_QUOTED='value with spaces'
+                DOUBLE_QUOTED="value=with=separators"
+                EMPTY=
+                """.trimIndent()
+            )
+        }
+
+        val result = loadEnvironmentFiles(listOf(file), inheritedEnvironment = emptyMap())
+
+        assertEquals(
+            mapOf(
+                "PLAIN" to "value",
+                "SINGLE_QUOTED" to "value with spaces",
+                "DOUBLE_QUOTED" to "value=with=separators",
+                "EMPTY" to "",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun rejectsInvalidDeclarations() {
+        val file = tempDir.resolve(".env").also { path ->
+            path.writeText("INVALID DECLARATION")
+        }
+
+        val error = assertFailsWith<UserReadableError> {
+            loadEnvironmentFiles(listOf(file), inheritedEnvironment = emptyMap())
+        }
+
+        assertEquals("Invalid environment variable declaration in $file at line 1", error.message)
+    }
+}

--- a/sources/test-integration/amper-wrapper-test/test/org/jetbrains/amper/cli/test/AmperShellScriptsTest.kt
+++ b/sources/test-integration/amper-wrapper-test/test/org/jetbrains/amper/cli/test/AmperShellScriptsTest.kt
@@ -134,6 +134,46 @@ class AmperShellScriptsTest : AmperCliWithWrapperTestBase() {
         }
     }
 
+    @Test
+    fun `shell script loads project environment file without overriding process environment`() = runBlocking {
+        val templatePath = shellScriptExampleProject
+        assertTrue { templatePath.isDirectory() }
+        templatePath.copyToRecursively(tempDir, followLinks = false, overwrite = false)
+        tempDir.resolve(".env.dev").writeText(
+            """
+            KOTLIN_TOOLCHAIN_ENV_FILE_TEST=from-env-dev
+            KOTLIN_TOOLCHAIN_ENV_LAYER_TEST=from-env-dev
+            KOTLIN_TOOLCHAIN_ENV_OVERRIDE_TEST=from-env-dev
+            """.trimIndent()
+        )
+        tempDir.resolve(".env").writeText(
+            """
+            KOTLIN_TOOLCHAIN_ENV_SHARED_TEST=from-shared-env
+            KOTLIN_TOOLCHAIN_ENV_LAYER_TEST=from-shared-env
+            """.trimIndent()
+        )
+
+        val result = runAmper(
+            workingDir = tempDir,
+            args = listOf("--env-file", ".env", "--env-file=.env.dev", "run"),
+            environment = mapOf("KOTLIN_TOOLCHAIN_ENV_OVERRIDE_TEST" to "from-process-environment"),
+            amperJavaHomeMode = JavaHomeMode.Custom(jreHomePath = provisionZulu25()),
+        )
+
+        assertTrue("Project environment file value must be available to the application. Output:\n${result.stdout}") {
+            result.stdout.contains("Environment from project file: from-env-dev")
+        }
+        assertTrue("Variables from later environment files must be available to the application. Output:\n${result.stdout}") {
+            result.stdout.contains("Environment from shared file: from-shared-env")
+        }
+        assertTrue("Later environment files must take precedence over earlier files. Output:\n${result.stdout}") {
+            result.stdout.contains("Environment layer: from-env-dev")
+        }
+        assertTrue("Process environment must take precedence over the project environment file. Output:\n${result.stdout}") {
+            result.stdout.contains("Environment override: from-process-environment")
+        }
+    }
+
     /**
      * It's expected on the start that wrappers and cli dist are published to maven local
      */

--- a/sources/test-integration/test-projects/shell-scripts/src/main.kt
+++ b/sources/test-integration/test-projects/shell-scripts/src/main.kt
@@ -1,3 +1,11 @@
 fun main() {
     println("Hello for Shell Scripts Test")
+    printEnvironmentVariable("KOTLIN_TOOLCHAIN_ENV_FILE_TEST", "Environment from project file")
+    printEnvironmentVariable("KOTLIN_TOOLCHAIN_ENV_SHARED_TEST", "Environment from shared file")
+    printEnvironmentVariable("KOTLIN_TOOLCHAIN_ENV_LAYER_TEST", "Environment layer")
+    printEnvironmentVariable("KOTLIN_TOOLCHAIN_ENV_OVERRIDE_TEST", "Environment override")
+}
+
+private fun printEnvironmentVariable(name: String, label: String) {
+    System.getenv(name)?.let { value -> println("$label: $value") }
 }


### PR DESCRIPTION
## Problem

Projects often need environment-specific settings such as `.env.dev` and `.env.prod` for build plugins and application runs. Loading these files in generated `kotlin` or `kotlin.bat` wrappers duplicates platform-specific parsing logic and makes wrapper updates overwrite project customizations.

## Changes

- add an explicit, repeatable root `--env-file=<path>` option
- parse dotenv files as data before project initialization or task execution, without shell evaluation or interpolation
- restart through the active Kotlin Toolchain wrapper with the merged environment so build plugins and launched applications receive the values
- keep inherited process variables at highest precedence; later files override earlier files
- support arbitrary names and layering, for example `--env-file .env --env-file .env.dev`
- document syntax, precedence, `.env.dev`, and `.env.prod` examples
- leave the POSIX and Windows wrapper scripts/templates unchanged

This is related to the environment-specific configuration use cases discussed in [AMPER-3854](https://youtrack.jetbrains.com/issue/AMPER-3854), while remaining explicit and independent from IDE run-configuration environment support in [AMPER-4824](https://youtrack.jetbrains.com/issue/AMPER-4824).

## Verification

- `./kotlin test -m amper-cli --include-classes org.jetbrains.amper.cli.EnvironmentFileTest` (4 tests passed)
- focused wrapper/application integration test (1 test passed)
- `./kotlin test -m amper-cli -m amper-wrapper-test`
- `./kotlin check -m amper-cli -m amper-wrapper-test` (`Check successful`)
- verified the local snapshot help exposes `--env-file=<path>`
- verified `kotlin`, `kotlin.bat`, and both wrapper templates have no diff

The full wrapper suite passed on macOS (9 passed, 2 Windows-only installer tests skipped by OS condition). The implementation is in shared JVM CLI code used after both POSIX and Windows wrappers bootstrap the distribution.