### PR TITLE
android: accept licenses listed in settings.android.acceptedLicenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ shared test caches/
 
 local.properties
 keystore.properties
+
+# Test-run artifacts (amper junit listener debug logs)
+junit-jupiter/

--- a/sources/amper-cli/src/org/jetbrains/amper/tasks/android/AndroidSdkLicenseChecker.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/tasks/android/AndroidSdkLicenseChecker.kt
@@ -41,6 +41,26 @@ internal class AndroidSdkLicenseChecker(
                 .sorted()
         }
     }
+
+    /**
+     * Writes the license hash files for the given ids into the SDK's licenses
+     * directory — the same acceptance that `sdkmanager --licenses` performs.
+     * Only the listed licenses are accepted, never anything else. Returns the
+     * ids that were actually written (unknown ids are ignored).
+     */
+    fun acceptLicenses(ids: Set<String>): Set<String> {
+        val licensesById = findAndroidSdkPackageManifests(normalizedAndroidSdkPath)
+            .map(packageLicenseReader)
+            .associateBy { it.id }
+        val written = mutableSetOf<String>()
+        for (id in ids) {
+            val license = licensesById[id] ?: continue
+            if (license.setAccepted(normalizedAndroidSdkPath)) {
+                written += id
+            }
+        }
+        return written
+    }
 }
 
 internal fun findAndroidSdkPackageManifests(androidSdkPath: Path): Set<Path> = buildSet {

--- a/sources/amper-cli/src/org/jetbrains/amper/tasks/android/CheckAndroidSdkLicenseTask.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/tasks/android/CheckAndroidSdkLicenseTask.kt
@@ -18,18 +18,30 @@ class CheckAndroidSdkLicenseTask(
     private val androidSdkPath: Path,
     private val userCacheRoot: AmperUserCacheRoot,
     private val incrementalCache: IncrementalCache,
+    private val acceptedLicenseIds: Set<String>,
     override val taskName: TaskName,
 ): Task {
     context(executionContext: TaskGraphExecutionContext)
     override suspend fun run(dependenciesResult: List<TaskResult>): TaskResult {
-        val unacceptedLicenseIds = SdkInstallManager(userCacheRoot, androidSdkPath)
-            .findUnacceptedSdkLicenseIds(incrementalCache)
+        val installManager = SdkInstallManager(userCacheRoot, androidSdkPath)
+        val unacceptedLicenseIds = installManager.findUnacceptedSdkLicenseIds(incrementalCache)
         if (unacceptedLicenseIds.isNotEmpty()) {
-            val licensesListText = unacceptedLicenseIds.joinToString("\n") { " - $it" }
-            val licensesCommand = "${androidSdkPath / "cmdline-tools" / "latest" / "bin" / "sdkmanager"} --licenses"
-            userReadableError("Some licenses have not been accepted in the Android SDK:\n" +
-                    "$licensesListText\n" +
-                    "Run \"$licensesCommand\" to review and accept them")
+            // Licenses the user explicitly listed in settings.android.acceptedLicenses
+            // are accepted here (hash files written), like sdkmanager --licenses would.
+            val acceptedByUser = acceptedLicenseIds.intersect(unacceptedLicenseIds.toSet())
+            if (acceptedByUser.isNotEmpty()) {
+                installManager.acceptSdkLicenses(acceptedByUser, incrementalCache)
+            }
+            val remaining = installManager.findUnacceptedSdkLicenseIds(incrementalCache)
+            if (remaining.isNotEmpty()) {
+                val licensesListText = remaining.joinToString("\n") { " - $it" }
+                val licensesCommand = "${androidSdkPath / "cmdline-tools" / "latest" / "bin" / "sdkmanager"} --licenses"
+                userReadableError("Some licenses have not been accepted in the Android SDK:\n" +
+                        "$licensesListText\n" +
+                        "Run \"$licensesCommand\" to review and accept them, or list the licenses you " +
+                        "explicitly accept in module.yaml under settings.android.acceptedLicenses " +
+                        "(e.g. [android-sdk-license])")
+            }
         }
         return Result()
     }

--- a/sources/amper-cli/src/org/jetbrains/amper/tasks/android/SdkInstallManager.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/tasks/android/SdkInstallManager.kt
@@ -182,9 +182,19 @@ class SdkInstallManager(private val userCacheRoot: AmperUserCacheRoot, private v
         get(url).bodyAsChannel().toInputStream().use { it.unmarshal<Repository>() }
 
     suspend fun findUnacceptedSdkLicenseIds(incrementalCache: IncrementalCache): List<String> =
+        licenseChecker(incrementalCache).findUnacceptedLicenseIds()
+
+    /**
+     * Writes the license hash files for the given ids (explicit user acceptance,
+     * see settings.android.acceptedLicenses). Returns the ids actually written.
+     */
+    suspend fun acceptSdkLicenses(licenseIds: Set<String>, incrementalCache: IncrementalCache): Set<String> =
+        licenseChecker(incrementalCache).acceptLicenses(licenseIds)
+
+    private fun licenseChecker(incrementalCache: IncrementalCache) =
         AndroidSdkLicenseChecker(androidSdkPath, incrementalCache) { packageManifest ->
             packageManifest.readRepository().localPackage.license
-        }.findUnacceptedLicenseIds()
+        }
 
     private fun writePackageXml(pkg: RemotePackage, localPackagePath: Path): LocalPackage {
         val localPackage = LocalPackageImpl.create(pkg)

--- a/sources/amper-cli/src/org/jetbrains/amper/tasks/android/taskBuilderAndroid.kt
+++ b/sources/amper-cli/src/org/jetbrains/amper/tasks/android/taskBuilderAndroid.kt
@@ -40,6 +40,9 @@ fun ProjectTasksBuilder.setupAndroidTasks() {
                 androidSdkPath = androidSdkPath,
                 userCacheRoot = context.userCacheRoot,
                 incrementalCache = context.incrementalCache,
+                acceptedLicenseIds = module.fragments
+                    .flatMap { it.settings.android.acceptedLicenses }
+                    .toSet(),
                 taskName = AndroidTaskType.CheckAndroidSdkLicense.getTaskName(module, Platform.ANDROID),
             ),
             dependsOn = AndroidTaskType.InstallCmdlineTools.getTaskName(module, Platform.ANDROID)

--- a/sources/amper-cli/test/org/jetbrains/amper/tasks/android/AndroidSdkLicenseCheckerTest.kt
+++ b/sources/amper-cli/test/org/jetbrains/amper/tasks/android/AndroidSdkLicenseCheckerTest.kt
@@ -13,12 +13,16 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.deleteExisting
 import kotlin.io.path.div
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.moveTo
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AndroidSdkLicenseCheckerTest {
     @TempDir
@@ -70,6 +74,37 @@ class AndroidSdkLicenseCheckerTest {
         // Use a new cache instance, as a new CLI invocation would.
         assertEquals(listOf("license-a", "license-z"), checker().findUnacceptedLicenseIds())
         assertEquals(3, parserInvocations, "manifests must not be parsed on a cache hit")
+    }
+
+    @Test
+    fun `acceptLicenses writes the hash files for the given ids`() = runBlocking {
+        val sdkRoot = (tempDir / "sdk").also { it.createDirectories() }
+        writeManifest(sdkRoot, "platforms/android-36", licenseId = "license-a")
+        writeManifest(sdkRoot, "build-tools/36.0.0", licenseId = "license-b")
+        val checker = AndroidSdkLicenseChecker(
+            sdkRoot,
+            createIncrementalCache(),
+        ) { path -> path.readTestLicense() }
+
+        assertEquals(listOf("license-a", "license-b"), checker.findUnacceptedLicenseIds())
+
+        assertEquals(setOf("license-b"), checker.acceptLicenses(setOf("license-b")))
+        assertTrue((sdkRoot / "licenses" / "license-b").isRegularFile())
+        assertEquals(listOf("license-a"), checker.findUnacceptedLicenseIds())
+    }
+
+    @Test
+    fun `acceptLicenses ignores unknown ids and never writes unlisted licenses`() = runBlocking {
+        val sdkRoot = (tempDir / "sdk").also { it.createDirectories() }
+        writeManifest(sdkRoot, "platforms/android-36", licenseId = "license-a")
+        val checker = AndroidSdkLicenseChecker(
+            sdkRoot,
+            createIncrementalCache(),
+        ) { path -> path.readTestLicense() }
+
+        assertEquals(emptySet(), checker.acceptLicenses(setOf("license-unknown")))
+        assertFalse((sdkRoot / "licenses" / "license-a").exists())
+        assertEquals(listOf("license-a"), checker.findUnacceptedLicenseIds())
     }
 
     @Test

--- a/sources/frontend-api/src/org/jetbrains/amper/frontend/schema/androidSettings.kt
+++ b/sources/frontend-api/src/org/jetbrains/amper/frontend/schema/androidSettings.kt
@@ -24,6 +24,14 @@ value class AndroidVersion(val versionNumber: Int): Comparable<AndroidVersion> {
 }
 
 class AndroidSettings : SchemaNode() {
+    @SchemaDoc("Android SDK license IDs whose terms are explicitly accepted by the user. " +
+            "When the license check finds one of these licenses unaccepted, the toolchain " +
+            "writes its hash file into the SDK's licenses directory instead of failing, so " +
+            "a fresh machine or a CI runner can build without running sdkmanager --licenses. " +
+            "Only the listed licenses are accepted; the toolchain never accepts licenses " +
+            "implicitly. License texts: https://developer.android.com/studio/intro/update#downloads")
+    val acceptedLicenses: List<String> by value(default = emptyList())
+
     @Misnomers("minApiLevel")
     @SchemaDoc("Minimum API level needed to run the application. " +
             "[Read more](https://developer.android.com/guide/topics/manifest/uses-sdk-element.html)")


### PR DESCRIPTION
Fixes the first-run / CI gap discussed in [KTC-5695](https://youtrack.jetbrains.com/issue/KTC-5695): the license check fails on a fresh machine until the user runs the provisioned `sdkmanager --licenses` — which is interactive, and on a machine with only the toolchain (no system JDK) fails outright with "JAVA_HOME is not set" because the command does not point at the provisioned JDK.

## What this adds

A new `settings.android.acceptedLicenses` setting: the user lists the SDK license ids whose terms they explicitly accept, and the toolchain writes the corresponding hash files into the SDK's licenses directory during the license check (the same acceptance `sdkmanager --licenses` performs, via `License.setAccepted`), then the build continues.

```yaml
product: android/app
settings:
  android:
    acceptedLicenses:
      - android-sdk-license
```

Only the listed licenses are ever accepted — the toolchain never accepts licenses implicitly (the legal point from the KTC-5695 discussion). Unaccepted licenses not in the list still fail the build, with the sdkmanager hint updated to mention the new option.

## Design notes

- The hash files are written with the repository library's own `License.setAccepted(Path)`, so the written state is exactly what the library considers accepted.
- The incremental cache needs no changes: the license check is cached keyed on the license files, so writing them invalidates it automatically (verified by the existing cache tests).
- The task collects the accepted ids from all fragments of the module at registration; the ids are matched against the licenses actually referenced by the installed SDK packages (unknown ids are ignored).

## Testing

- `amper-cli` and `schema` modules compile.
- `AndroidSdkLicenseCheckerTest`: 10/10 pass, including two new tests (hash file written for a listed license; unknown ids ignored, unlisted licenses never written).
- `SdkInstallManagerTest`: 14/14 pass.
- `TreeTests` (frontend schema golden files): 15/15 pass — no golden updates needed since the setting defaults to empty.

Live demonstration on a real machine: with the licenses directory removed, `kotlin build` fails with the expected message; after the new logic is in place, a module listing `acceptedLicenses: [android-sdk-license]` builds to an APK with no sdkmanager step.
