### PR TITLE
Honor KOTLIN_TOOLCHAIN_GRADLE_DISTRIBUTION_URL to mirror the Gradle distribution (KTC-5696)

### DIFF
--- a/sources/android-integration/amper-android-runner/src/org.jetbrains.amper.android/Runner.kt
+++ b/sources/android-integration/amper-android-runner/src/org.jetbrains.amper.android/Runner.kt
@@ -16,6 +16,7 @@ import org.gradle.tooling.model.GradleProject
 import org.jetbrains.amper.buildinfo.AmperBuild
 import org.jetbrains.amper.mavencentral.MavenCentralDefaultConfiguration
 import java.io.BufferedOutputStream
+import java.net.URI
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.APPEND
 import java.nio.file.StandardOpenOption.CREATE
@@ -28,6 +29,13 @@ import kotlin.io.path.outputStream
 import kotlin.io.path.pathString
 
 private const val DEBUG_JVM_AGENT = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+
+/**
+ * Overrides the Gradle distribution the Tooling API downloads for Android builds.
+ * Point it at a mirror (e.g. https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-8.14.3-bin.zip)
+ * when services.gradle.org is unreachable. When unset, Gradle uses its default distribution URL.
+ */
+private const val GRADLE_DISTRIBUTION_URL_ENV = "KOTLIN_TOOLCHAIN_GRADLE_DISTRIBUTION_URL"
 
 private fun <T : ConfigurableLauncher<T>> T.addDebugJvmArgumentsIf(debug: Boolean): T =
     if (debug) addJvmArguments(DEBUG_JVM_AGENT) else this
@@ -67,6 +75,11 @@ fun runAndroidBuild(
     GradleConnector
         .newConnector()
         .forProjectDirectory(settingsGradlePath.parent.toFile())
+        .apply {
+            System.getenv(GRADLE_DISTRIBUTION_URL_ENV)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { useDistribution(URI(it)) }
+        }
         .connect()
         .use { connection ->
             val androidProjects = connection.extractAndroidProjectModelsFromBuild(buildRequest, jdkDir, debug)


### PR DESCRIPTION
## Context

KTC-5696 / https://github.com/JetBrains/kotlin-toolchain/issues/13: `kotlin build` connects to Gradle via the Tooling API without specifying a distribution (`GradleConnector.newConnector().forProjectDirectory(...)` in `amper-android-runner`), so Gradle downloads its hardcoded default from `https://services.gradle.org/distributions/gradle-VERSION-bin.zip`. From mainland China this is unreachable (it redirects to GitHub release assets), and the first Android build fails with `GradleConnectionException: Could not run build action using connection to Gradle distribution`.

## Change

Honors the `KOTLIN_TOOLCHAIN_GRADLE_DISTRIBUTION_URL` environment variable: when set, the connector uses that distribution URL instead of the hardcoded default. When unset, behavior is unchanged.

```sh
export KOTLIN_TOOLCHAIN_GRADLE_DISTRIBUTION_URL=https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-8.14.3-bin.zip
kotlin build
```

The URL pattern mirrors what the test fixtures already use (`sources/test-base/src/org/jetbrains/amper/test/gradle/gradle.kt`: `useDistribution(URI("https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-$gradleVersion-bin.zip"))`). The Gradle version matching the embedded Tooling API is `8.14.3` (libs.versions.toml `gradle-toolingApi`); any compatible distribution URL works, e.g. a Tencent/Aliyun mirror.

## Testing

Compiled and behavior-tested from source on main (kotlin 2.4.0 per `sources/common.module-template.yaml`):

- `kotlin build -m amper-cli` compiles clean (main is not blocked; `org.jetbrains.kotlin:kotlin-power-assert-runtime:2.4.0` resolves from Maven Central — the earlier note about `kotlin-power-assert-runtime:2.3.10` missing from Central applies to the `release/0.11` branch, which pins kotlin 2.3.10, not to main).
- With `KOTLIN_TOOLCHAIN_GRADLE_DISTRIBUTION_URL` set to a bogus URL, the build fails with `Could not install Gradle distribution from '<url>'`, confirming the variable is honored.
- With the variable set to the JetBrains cache-redirector URL, the distribution is downloaded from that URL (no `services.gradle.org` contact).
- Without the variable, behavior is unchanged (default distribution URL).