### PR TITLE
docs: fix typo targetting -> targeting

### DIFF
--- a/docs/src/user-guide/product-types/wasm-wasi-app.md
+++ b/docs/src/user-guide/product-types/wasm-wasi-app.md
@@ -51,7 +51,7 @@ There are no extra packaging facilities at the moment, and the `package` command
 
 ## Running WASI application
 
-!!! warning "Kotlin/Wasm application targetting WASI cannot be run directly by the Kotlin CLI at the moment."
+!!! warning "Kotlin/Wasm application targeting WASI cannot be run directly by the Kotlin CLI at the moment."
 
 To run WASI application, you need to:
 


### PR DESCRIPTION
One-word typo fix in `docs/src/user-guide/product-types/wasm-wasi-app.md:54`: "Kotlin/Wasm application targetting WASI" -> "targeting".
